### PR TITLE
Breaking change: typo send_inteval => send_interval

### DIFF
--- a/aiozipkin/tracer.py
+++ b/aiozipkin/tracer.py
@@ -91,12 +91,12 @@ class Tracer(AsyncContextManager):
 def create(zipkin_address: str,
            local_endpoint: Endpoint, *,
            sample_rate: float=0.01,
-           send_inteval: float=5,
+           send_interval: float=5,
            loop: OptLoop=None) -> Awaitable[Tracer]:
 
     async def f() -> Tracer:
         sampler = Sampler(sample_rate=sample_rate)
-        transport = Transport(zipkin_address, send_inteval=send_inteval, loop=loop)
+        transport = Transport(zipkin_address, send_interval=send_interval, loop=loop)
         return Tracer(transport, sampler, local_endpoint)
     result = _ContextManager(f())  # type: Awaitable[Tracer]
     return result

--- a/aiozipkin/transport.py
+++ b/aiozipkin/transport.py
@@ -11,12 +11,12 @@ from .record import Record
 
 class Transport:
 
-    def __init__(self, address: str, send_inteval: float=5,
+    def __init__(self, address: str, send_interval: float=5,
                  loop: OptLoop=None) -> None:
         self._address = URL(address) / 'api/v2/spans'
         self._queue = []  # type: List[Dict[str, Any]]
         self._closing = False
-        self._send_interval = send_inteval
+        self._send_interval = send_interval
         self._loop = loop or asyncio.get_event_loop()
         self._session = aiohttp.ClientSession(loop=self._loop)
         self._sender_task = asyncio.ensure_future(

--- a/tests/test_jaeger.py
+++ b/tests/test_jaeger.py
@@ -10,7 +10,7 @@ async def test_basic(jaeger_url, jaeger_api_url, client, loop):
     endpoint = az.create_endpoint('simple_service', ipv4='127.0.0.1', port=80)
     interval = 50
     tracer = await az.create(jaeger_url, endpoint, sample_rate=1.0,
-                             send_inteval=interval, loop=loop)
+                             send_interval=interval, loop=loop)
 
     with tracer.new_trace(sampled=True) as span:
         span.name('jaeger_span')

--- a/tests/test_zipkin.py
+++ b/tests/test_zipkin.py
@@ -13,7 +13,7 @@ async def test_basic(zipkin_url, client, loop):
     endpoint = az.create_endpoint('simple_service', ipv4='127.0.0.1', port=80)
     interval = 50
     tracer = await az.create(zipkin_url, endpoint, sample_rate=1.0,
-                             send_inteval=interval, loop=loop)
+                             send_interval=interval, loop=loop)
 
     with tracer.new_trace(sampled=True) as span:
         span.name('root_span')
@@ -39,7 +39,7 @@ async def test_basic_context_manager(zipkin_url, client, loop):
     endpoint = az.create_endpoint('simple_service', ipv4='127.0.0.1', port=80)
     interval = 50
     async with az.create(zipkin_url, endpoint, sample_rate=1.0,
-                         send_inteval=interval) as tracer:
+                         send_interval=interval) as tracer:
         with tracer.new_trace(sampled=True) as span:
             span.name('root_span')
             await asyncio.sleep(0.1)
@@ -58,7 +58,7 @@ async def test_basic_context_manager(zipkin_url, client, loop):
 async def test_exception_in_span(zipkin_url, client, loop):
     endpoint = az.create_endpoint('error_service', ipv4='127.0.0.1', port=80)
     interval = 50
-    async with az.create(zipkin_url, endpoint, send_inteval=interval,
+    async with az.create(zipkin_url, endpoint, send_interval=interval,
                          loop=loop) as tracer:
         def func(span):
             with span:
@@ -96,7 +96,7 @@ async def test_zipkin_error(client, loop, caplog):
     interval = 50
     zipkin_url = 'https://httpbin.org/status/400'
     async with az.create(zipkin_url, endpoint, sample_rate=1.0,
-                         send_inteval=interval, loop=loop) as tracer:
+                         send_interval=interval, loop=loop) as tracer:
         with tracer.new_trace(sampled=True) as span:
             span.kind(az.CLIENT)
             await asyncio.sleep(0.0)
@@ -117,7 +117,7 @@ async def test_leak_in_transport(zipkin_url, client, loop):
 
     endpoint = az.create_endpoint('simple_service')
     tracer = await az.create(zipkin_url, endpoint, sample_rate=1,
-                             send_inteval=0.0001, loop=loop)
+                             send_interval=0.0001, loop=loop)
 
     await asyncio.sleep(5)
     gc.collect()


### PR DESCRIPTION
There is a typo, and I think it is better to fix it when aiozipkin has version 0.3 than later