### PR TITLE
Additional typos

### DIFF
--- a/aiozipkin/aiohttp_helpers.py
+++ b/aiozipkin/aiohttp_helpers.py
@@ -157,7 +157,7 @@ def get_tracer(app: Application, tracer_key: str=APP_AIOZIPKIN_KEY) -> Tracer:
 
 def request_span(request: Request,
                  request_key: str=REQUEST_AIOZIPKIN_KEY) -> SpanAbc:
-    """Return span created by middleware from request context, you can use it
+    """Returns span created by middleware from request context, you can use it
     as parent on next child span.
     """
     return cast(SpanAbc, request[request_key])

--- a/aiozipkin/helpers.py
+++ b/aiozipkin/helpers.py
@@ -54,13 +54,13 @@ Endpoint = NamedTuple(
 )
 
 
-def create_endpoint(servce_name: str, *,
+def create_endpoint(service_name: str, *,
                     ipv4: OptStr=None,
                     ipv6: OptStr=None,
                     port: OptInt=None) -> Endpoint:
     """Factory function to create Endpoint object.
     """
-    return Endpoint(servce_name, ipv4, ipv6, port)
+    return Endpoint(service_name, ipv4, ipv6, port)
 
 
 def make_timestamp(ts: OptTs=None) -> int:

--- a/aiozipkin/helpers.py
+++ b/aiozipkin/helpers.py
@@ -65,7 +65,7 @@ def create_endpoint(service_name: str, *,
 
 def make_timestamp(ts: OptTs=None) -> int:
     """Create zipkin timestamp in microseconds, or convert available one
-    from second. Useful when user supply ts from time.time() call.
+    from second. Useful when user supplies ts from time.time() call.
     """
     ts = ts if ts is not None else time.time()
     return int(ts * 1000 * 1000)  # microseconds

--- a/demos/microservices/service_a.py
+++ b/demos/microservices/service_a.py
@@ -13,6 +13,7 @@ service_e_api = 'http://127.0.0.1:9005/api/v1/data'
 host = '127.0.0.1'
 port = 9001
 zipkin_address = 'http://127.0.0.1:9411/api/v2/spans'
+zipkin_ui_address = 'http://127.0.0.1:9411/zipkin/'
 
 
 async def handler(request):
@@ -34,7 +35,7 @@ async def handler(request):
         'children': [data_b, data_e],
     }
     ctx = {
-        'zipkin':  zipkin_address,
+        'zipkin':  zipkin_ui_address,
         'service': tree
     }
     return aiohttp_jinja2.render_template('index.html', request, ctx)

--- a/demos/microservices/service_c.py
+++ b/demos/microservices/service_c.py
@@ -11,7 +11,7 @@ port = 9002
 async def handler(request):
     await asyncio.sleep(0.01)
     payload = {
-        'name': 'servcie_c',
+        'name': 'service_c',
         'host': host,
         'port': port,
         'children': [],

--- a/demos/microservices/service_d.py
+++ b/demos/microservices/service_d.py
@@ -11,7 +11,7 @@ port = 9004
 async def handler(request):
     await asyncio.sleep(0.01)
     payload = {
-        'name': 'servcie_d',
+        'name': 'service_d',
         'host': host,
         'port': port,
         'children': [],

--- a/demos/microservices/templates/index.html
+++ b/demos/microservices/templates/index.html
@@ -1,7 +1,7 @@
 {% macro render_service(service) -%}
 <div class="uk-card uk-card-default uk-card-body uk-card-hover">
     <h3 class="uk-card-title uk-heading-line">
-        <a href="http://{{service.host}}:{{service.port}}/api/v1/data"target="_blank">{{service.name}}</a>
+        <a href="http://{{service.host}}:{{service.port}}/api/v1/data" target="_blank">{{service.name}}</a>
     </h3>
     <ul>
         <li>host: {{service.host}}</li>
@@ -31,10 +31,10 @@
             <article class="uk-article">
                 <h1 class="uk-article-title"><a class="uk-link-reset" href="">aiozipkin microservices demo</a></h1>
                 <p class="uk-text-lead">
-                    There is larger micro services example, using <a hre"https://github.com/aio-libs/aiohttp">aiohttp</a>.
-                    This demo consists of five simple services that call each other, as result you can study client
+                    There is a larger micro services example, using <a href="https://aiohttp.readthedocs.io/en/stable/">aiohttp</a>.
+                    This demo consists of five simple services that call each other, as a result you can study client
                     server communication and zipkin integration for large projects. Each
-                    box element of this page rendered with help of different service.
+                    box element of this page is rendered with help of different service.
                 </p>
                 <p><span class="uk-label">Zipkin UI</span> <a href="{{zipkin}}" target="_blank">{{zipkin}}</a></p>
                 {{ render_service(service) }}
@@ -43,7 +43,7 @@
             <hr class="uk-divider-icon">
             <h5 class="uk-text-center">
                 <span>
-                    <a hre"https://github.com/aio-libs/aiozipkin">https://github.com/aio-libs/aiozipkin</a>
+                    <a href="https://github.com/aio-libs/aiozipkin">https://github.com/aio-libs/aiozipkin</a>
                 </span>
             </h5>
         </div>


### PR DESCRIPTION
Fix some more typos and make examples a bit better. Unfortunately contains a breaking change in `create_endpoint`.