### PR TITLE
Abstract away Sampler and add create_custom(transport, sampler)

### DIFF
--- a/aiozipkin/sampler.py
+++ b/aiozipkin/sampler.py
@@ -7,7 +7,7 @@ from .mypy_types import OptInt
 class SamplerABC(abc.ABC):
 
     @abc.abstractmethod
-    def is_sampled(self, trace_id: str) -> bool:
+    def is_sampled(self, trace_id: str) -> bool:  # pragma: no cover
         """Defines if given trace should be recorded for further actions."""
         pass
 

--- a/aiozipkin/sampler.py
+++ b/aiozipkin/sampler.py
@@ -1,9 +1,18 @@
+import abc
 from random import Random
 
 from .mypy_types import OptInt
 
 
-class Sampler:
+class SamplerABC(abc.ABC):
+
+    @abc.abstractmethod
+    def is_sampled(self, trace_id: str) -> bool:
+        """Defines if given trace should be recorded for further actions."""
+        pass
+
+
+class Sampler(SamplerABC):
 
     def __init__(self, *, sample_rate: float=1.0, seed: OptInt=None) -> None:
         self._sample_rate = sample_rate

--- a/aiozipkin/transport.py
+++ b/aiozipkin/transport.py
@@ -14,12 +14,12 @@ from .record import Record
 class TransportABC(abc.ABC):
 
     @abc.abstractmethod
-    def send(self, record: Record) -> None:
+    def send(self, record: Record) -> None:  # pragma: no cover
         """Sends data to zipkin collector."""
         pass
 
     @abc.abstractmethod
-    async def close(self) -> None:
+    async def close(self) -> None:  # pragma: no cover
         """Performs additional cleanup actions if required."""
         pass
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,6 +44,15 @@ Core API Reference
    :param asyncio.EventLoop loop: hostname to serve monitor telnet server
    :returns: Tracer
 
+.. cofunction:: create_custom(transport, sampler, local_endpoint)
+
+    Creates Tracer object with a custom Transport and Sampler implementation.
+
+    :param TransportABC transport: custom transport implementation
+    :param SamplerABC sampler: custom sampler implementation
+    :param Endpoint local_endpoint: hostname to serve monitor telnet server
+    :returns: Tracer
+
 .. class:: Endpoint(serviceName: str, ipv4=None, ipv6=None, port=None)
 
    This this simple data only class, just holder for service related


### PR DESCRIPTION
Abstract away Sampler class, to ease implementing custom ones while keeping the contract and add a `create_custom` method for creating a new Tracer with custom Sampler and Transport classes