### PR TITLE
Use xenial for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: required
-
+dist: xenial
 
 python:
   - '3.6'


### PR DESCRIPTION
Trusty doesn't seem to have python 3.7 for testing available.