### PR TITLE
Add retries and batches to transport (#204)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 import gc
 
 import aiohttp
+from aiohttp import web
 from aiozipkin.helpers import create_endpoint, TraceContext
 from aiozipkin.sampler import Sampler
 from aiozipkin.tracer import Tracer
@@ -9,6 +10,7 @@ from aiozipkin.transport import StubTransport
 from async_generator import yield_, async_generator
 
 import pytest
+from aiohttp.test_utils import TestServer
 
 
 @pytest.fixture(scope='session')
@@ -56,6 +58,66 @@ def context():
 async def client(loop):
     async with aiohttp.ClientSession(loop=loop) as client:
         await yield_(client)
+
+
+class FakeZipkin:
+
+    def __init__(self, loop):
+        self.next_errors = []
+        self.app = web.Application()
+        self.app.router.add_post('/api/v2/spans', self.spans_handler)
+        self.port = None
+        self._loop = loop
+        self._received_data = []
+        self._wait_count = None
+        self._wait_fut = None
+
+    @property
+    def url(self):
+        return 'http://127.0.0.1:%s/api/v2/spans' % self.port
+
+    async def spans_handler(self, request: web.Request) -> web.Response:
+        if len(self.next_errors) > 0:
+            err = self.next_errors.pop(0)
+            if err == 'disconnect':
+                request.transport.close()
+                await asyncio.sleep(1, loop=self._loop)
+            elif err == 'timeout':
+                await asyncio.sleep(60, loop=self._loop)
+            return web.HTTPInternalServerError()
+
+        data = await request.json()
+        if self._wait_count is not None:
+            self._wait_count -= 1
+        self._received_data.append(data)
+        if self._wait_fut is not None and self._wait_count == 0:
+            self._wait_fut.set_result(None)
+
+        return aiohttp.web.Response(text='', status=200)
+
+    def get_received_data(self) -> list:
+        data = self._received_data
+        self._received_data = []
+        return data
+
+    def wait_data(self, count):
+        self._wait_fut = asyncio.Future(loop=self._loop)
+        self._wait_count = count
+        return self._wait_fut
+
+
+@pytest.fixture
+@async_generator
+async def fake_zipkin(loop):
+    zipkin = FakeZipkin(loop=loop)
+
+    server = TestServer(zipkin.app, loop=loop)
+    await server.start_server()
+    zipkin.port = server.port
+
+    await yield_(zipkin)
+
+    await server.close()
 
 
 pytest_plugins = ['docker_fixtures']

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,127 @@
+import asyncio
+from aiohttp.client import ClientTimeout
+
+import pytest
+import aiozipkin as az
+import aiozipkin.transport as azt
+
+
+@pytest.mark.asyncio
+async def test_retry(fake_zipkin, loop):
+    endpoint = az.create_endpoint('simple_service', ipv4='127.0.0.1', port=80)
+
+    tr = azt.Transport(fake_zipkin.url,
+                       send_interval=0.01,
+                       send_max_size=100,
+                       send_attempt_count=3,
+                       send_timeout=ClientTimeout(total=1))
+
+    fake_zipkin.next_errors.append('disconnect')
+    fake_zipkin.next_errors.append('timeout')
+    waiter = fake_zipkin.wait_data(1)
+
+    tracer = await az.create_custom(endpoint, tr)
+
+    with tracer.new_trace(sampled=True) as span:
+        span.name('root_span')
+        span.kind(az.CLIENT)
+
+    await waiter
+    await tracer.close()
+
+    data = fake_zipkin.get_received_data()
+    trace_id = span.context.trace_id
+    assert any(s['traceId'] == trace_id for trace in data for s in trace), data
+
+
+@pytest.mark.asyncio
+async def test_batches(fake_zipkin, loop):
+    endpoint = az.create_endpoint('simple_service', ipv4='127.0.0.1', port=80)
+
+    tr = azt.Transport(fake_zipkin.url,
+                       send_interval=0.01,
+                       send_max_size=2,
+                       send_timeout=ClientTimeout(total=1))
+
+    tracer = await az.create_custom(endpoint, tr)
+
+    with tracer.new_trace(sampled=True) as span:
+        span.name('root_span')
+        span.kind(az.CLIENT)
+        with span.new_child('child_1', az.CLIENT):
+            pass
+        with span.new_child('child_2', az.CLIENT):
+            pass
+
+    # close forced sending data to server regardless of send interval
+    await tracer.close()
+
+    data = fake_zipkin.get_received_data()
+    trace_id = span.context.trace_id
+    assert len(data[0]) == 2
+    assert len(data[1]) == 1
+    assert data[0][0]['name'] == 'child_1'
+    assert data[0][1]['name'] == 'child_2'
+    assert data[1][0]['name'] == 'root_span'
+    assert any(s['traceId'] == trace_id for trace in data for s in trace), data
+
+
+@pytest.mark.asyncio
+async def test_send_full_batch(fake_zipkin, loop):
+    endpoint = az.create_endpoint('simple_service', ipv4='127.0.0.1', port=80)
+
+    tr = azt.Transport(fake_zipkin.url,
+                       send_interval=60,
+                       send_max_size=2,
+                       send_timeout=ClientTimeout(total=1))
+
+    tracer = await az.create_custom(endpoint, tr)
+    waiter = fake_zipkin.wait_data(1)
+
+    with tracer.new_trace(sampled=True) as span:
+        span.name('root_span')
+        span.kind(az.CLIENT)
+
+    await asyncio.sleep(1, loop=loop)
+
+    data = fake_zipkin.get_received_data()
+    assert len(data) == 0
+
+    with tracer.new_trace(sampled=True) as span:
+        span.name('root_span')
+        span.kind(az.CLIENT)
+
+    # batch is full here
+    await waiter
+    data = fake_zipkin.get_received_data()
+    assert len(data) == 1
+
+    # close forced sending data to server regardless of send interval
+    await tracer.close()
+
+
+@pytest.mark.asyncio
+async def test_lost_spans(fake_zipkin, loop):
+    endpoint = az.create_endpoint('simple_service', ipv4='127.0.0.1', port=80)
+
+    tr = azt.Transport(fake_zipkin.url,
+                       send_interval=0.01,
+                       send_max_size=100,
+                       send_attempt_count=2,
+                       send_timeout=ClientTimeout(total=1))
+
+    fake_zipkin.next_errors.append('disconnect')
+    fake_zipkin.next_errors.append('disconnect')
+
+    tracer = await az.create_custom(endpoint, tr)
+
+    with tracer.new_trace(sampled=True) as span:
+        span.name('root_span')
+        span.kind(az.CLIENT)
+
+    await asyncio.sleep(1, loop=loop)
+
+    await tracer.close()
+
+    data = fake_zipkin.get_received_data()
+    assert len(data) == 0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Added retries to HTTP transport
Data is sent in batches

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Changed arguments in Transport constructor

## Related issue number

#204

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
