### PR TITLE
Update trace ID generation to match latest py_zipkin.

### DIFF
--- a/aiozipkin/utils.py
+++ b/aiozipkin/utils.py
@@ -1,10 +1,10 @@
-import binascii
-import os
+import random
 import struct
+import time
 
 
 # https://github.com/Yelp/py_zipkin/blob/
-# 7937ca859f8ae1f1009ab69fd1ddcd8fc33f1dad/py_zipkin/util.py#L1-L54
+# 61f8aa3412f6c1b4e1218ed34cb117e97cc9a6cc/py_zipkin/util.py#L22
 def generate_random_64bit_string() -> str:
     """Returns a 64 bit UTF-8 encoded string. In the interests of simplicity,
     this is always cast to a `str` instead of (in py2 land) a unicode string.
@@ -12,16 +12,24 @@ def generate_random_64bit_string() -> str:
 
     :returns: random 16-character string
     """
-    return str(binascii.hexlify(os.urandom(8)).decode('utf-8'))
+    return '{:016x}'.format(random.getrandbits(64))
 
 
+# https://github.com/Yelp/py_zipkin/blob/
+# 61f8aa3412f6c1b4e1218ed34cb117e97cc9a6cc/py_zipkin/util.py#L32
 def generate_random_128bit_string() -> str:
     """Returns a 128 bit UTF-8 encoded string. Follows the same conventions
     as generate_random_64bit_string().
 
-    :returns: random 32-character string
+    The upper 32 bits are the current time in epoch seconds, and the
+    lower 96 bits are random. This allows for AWS X-Ray `interop
+    <https://github.com/openzipkin/zipkin/issues/1754>`_
+
+    :returns: 32-character hex string
     """
-    return str(binascii.hexlify(os.urandom(16)).decode('utf-8'))
+    t = int(time.time())
+    lower_96 = random.getrandbits(96)
+    return '{:032x}'.format((t << 96) | lower_96)
 
 
 def unsigned_hex_to_signed_int(hex_string: str) -> int:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,4 +16,3 @@ pytest-asyncio==0.10.0
 pytest-cov==2.8.1
 pytest-sugar==0.9.2
 pytest==5.2.2
-typeshed==0.0.1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,9 +4,9 @@ from unittest import mock
 from aiozipkin import utils
 
 
-@mock.patch('aiozipkin.utils.binascii.hexlify', autospec=True)
+@mock.patch('aiozipkin.utils.random.getrandbits', autospec=True)
 def test_generate_random_64bit_string(rand):
-    rand.return_value = b'17133d482ba4f605'
+    rand.return_value = 0x17133d482ba4f605
     random_string = utils.generate_random_64bit_string()
     assert random_string == '17133d482ba4f605'
     # This acts as a contract test of sorts. This should return a str
@@ -14,9 +14,11 @@ def test_generate_random_64bit_string(rand):
     assert isinstance(random_string, str)
 
 
-@mock.patch('aiozipkin.utils.binascii.hexlify', autospec=True)
-def test_generate_random_128bit_string(rand):
-    rand.return_value = b'17133d482ba4f60517133d482ba4f605'
+@mock.patch('aiozipkin.utils.time.time', autospec=True)
+@mock.patch('aiozipkin.utils.random.getrandbits', autospec=True)
+def test_generate_random_128bit_string(rand, time):
+    rand.return_value = 0x2ba4f60517133d482ba4f605
+    time.return_value = 0x17133d48
     random_string = utils.generate_random_128bit_string()
     assert random_string == '17133d482ba4f60517133d482ba4f605'
     # This acts as a contract test of sorts. This should return a str


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Updates ID generation to match general Zipkin ecosystem and current version of py_zipkin

- Insecure random instead of secure random
- Prefix 128-bit ID with timestamp

Also removes `typeshed` dependency which was removed from PyPi

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

IDs are generally opaque strings and going from purely random to a slightly restricted random should have no affect on users.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
