### PR TITLE
Expect trace request context to be SimpleNamespace

### DIFF
--- a/CHANGES/385.bugfix
+++ b/CHANGES/385.bugfix
@@ -1,0 +1,1 @@
+Expect trace request context to be of SimpleNamespace type.

--- a/aiozipkin/aiohttp_helpers.py
+++ b/aiozipkin/aiohttp_helpers.py
@@ -287,12 +287,11 @@ class ZipkinClientSignals:
         ctx = context.trace_request_ctx
         propagate_headers = True
 
-        if ctx is not None:
-            if isinstance(ctx, dict):
-                # Check ctx is dict to be compatible with old package versions
-                propagate_headers = ctx.get("propagate_headers", True)
-            if isinstance(ctx, SimpleNamespace):
-                propagate_headers = getattr(ctx, "propagate_headers", True)
+        if isinstance(ctx, dict):
+            # Check ctx is dict to be compatible with old package versions
+            propagate_headers = ctx.get("propagate_headers", True)
+        if isinstance(ctx, SimpleNamespace):
+            propagate_headers = getattr(ctx, "propagate_headers", True)
 
         if propagate_headers:
             span_headers = span.context.make_headers()

--- a/aiozipkin/aiohttp_helpers.py
+++ b/aiozipkin/aiohttp_helpers.py
@@ -230,12 +230,14 @@ class ZipkinClientSignals:
     def _get_span_context(
         self, trace_config_ctx: SimpleNamespace
     ) -> Optional[TraceContext]:
-        trace_request_ctx = trace_config_ctx.trace_request_ctx
-        has_explicit_context = (
-            isinstance(trace_request_ctx, dict) and "span_context" in trace_request_ctx
-        )
-        if has_explicit_context:
-            r: TraceContext = trace_request_ctx["span_context"]
+        ctx = trace_config_ctx.trace_request_ctx
+
+        if isinstance(ctx, dict) and "span_context" in ctx:
+            r: TraceContext = ctx["span_context"]
+            return r
+
+        if isinstance(ctx, SimpleNamespace) and hasattr(ctx, "span_context"):
+            r = ctx.span_context
             return r
 
         if PY37:

--- a/aiozipkin/aiohttp_helpers.py
+++ b/aiozipkin/aiohttp_helpers.py
@@ -249,8 +249,8 @@ class ZipkinClientSignals:
     ) -> Optional[TraceContext]:
         ctx = trace_config_ctx.trace_request_ctx
 
-        if isinstance(ctx, dict) and "span_context" in ctx:
-            r: TraceContext = ctx["span_context"]
+        if isinstance(ctx, dict):
+            r: Optional[TraceContext] = ctx.get("span_context")
             return r
 
         return None
@@ -260,8 +260,8 @@ class ZipkinClientSignals:
     ) -> Optional[TraceContext]:
         ctx = trace_config_ctx.trace_request_ctx
 
-        if isinstance(ctx, SimpleNamespace) and hasattr(ctx, "span_context"):
-            r: TraceContext = ctx.span_context
+        if isinstance(ctx, SimpleNamespace):
+            r: Optional[TraceContext] = getattr(ctx, "span_context", None)
             return r
 
         return None

--- a/aiozipkin/aiohttp_helpers.py
+++ b/aiozipkin/aiohttp_helpers.py
@@ -233,10 +233,12 @@ class ZipkinClientSignals:
         ctx = trace_config_ctx.trace_request_ctx
 
         if isinstance(ctx, dict) and "span_context" in ctx:
-            return ctx["span_context"]
+            r: TraceContext = ctx["span_context"]
+            return r
 
         if isinstance(ctx, SimpleNamespace) and hasattr(ctx, "span_context"):
-            return ctx.span_context
+            r = ctx.span_context
+            return r
 
         if PY37:
             has_implicit_context = zipkin_context.get() is not None

--- a/aiozipkin/aiohttp_helpers.py
+++ b/aiozipkin/aiohttp_helpers.py
@@ -233,12 +233,10 @@ class ZipkinClientSignals:
         ctx = trace_config_ctx.trace_request_ctx
 
         if isinstance(ctx, dict) and "span_context" in ctx:
-            r: TraceContext = ctx["span_context"]
-            return r
+            return ctx["span_context"]
 
         if isinstance(ctx, SimpleNamespace) and hasattr(ctx, "span_context"):
-            r = ctx.span_context
-            return r
+            return ctx.span_context
 
         if PY37:
             has_implicit_context = zipkin_context.get() is not None

--- a/aiozipkin/aiohttp_helpers.py
+++ b/aiozipkin/aiohttp_helpers.py
@@ -264,7 +264,15 @@ class ZipkinClientSignals:
         span.kind(CLIENT)
 
         ctx = context.trace_request_ctx
-        propagate_headers = ctx is None or ctx.get("propagate_headers", True)
+        propagate_headers = True
+
+        if ctx is not None:
+            if isinstance(ctx, dict):
+                # Check ctx is dict to be compatible with old package versions
+                propagate_headers = ctx.get("propagate_headers", True)
+            if isinstance(ctx, SimpleNamespace):
+                propagate_headers = getattr(ctx, "propagate_headers", True)
+
         if propagate_headers:
             span_headers = span.context.make_headers()
             p.headers.update(span_headers)

--- a/tests/test_aiohttp_ingegration.py
+++ b/tests/test_aiohttp_ingegration.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from typing import Any
 
 import aiohttp
@@ -86,6 +87,12 @@ async def test_client_signals(tracer: az.Tracer, fake_transport: Any) -> None:
         url = "https://httpbin.org/get"
         # do not propagate headers
         ctx = {"span_context": span.context, "propagate_headers": False}
+        resp = await session.get(url, trace_request_ctx=ctx)
+        data = await resp.read()
+        assert len(data) > 0
+        assert az.make_context(resp.request_info.headers) is None
+
+        ctx = SimpleNamespace(span_context=span.context, propagate_headers=False)
         resp = await session.get(url, trace_request_ctx=ctx)
         data = await resp.read()
         assert len(data) > 0

--- a/tests/test_aiohttp_integration.py
+++ b/tests/test_aiohttp_integration.py
@@ -92,8 +92,8 @@ async def test_client_signals(tracer: az.Tracer, fake_transport: Any) -> None:
         assert len(data) > 0
         assert az.make_context(resp.request_info.headers) is None
 
-        ctx = SimpleNamespace(span_context=span.context, propagate_headers=False)
-        resp = await session.get(url, trace_request_ctx=ctx)
+        ctx_ns = SimpleNamespace(span_context=span.context, propagate_headers=False)
+        resp = await session.get(url, trace_request_ctx=ctx_ns)
         data = await resp.read()
         assert len(data) > 0
         assert az.make_context(resp.request_info.headers) is None
@@ -109,13 +109,15 @@ async def test_client_signals(tracer: az.Tracer, fake_transport: Any) -> None:
 
     await session.close()
 
-    assert len(fake_transport.records) == 3
+    assert len(fake_transport.records) == 4
     record1 = fake_transport.records[0].asdict()
     record2 = fake_transport.records[1].asdict()
     record3 = fake_transport.records[2].asdict()
-    assert record2["parentId"] == record3["id"]
-    assert record1["parentId"] == record3["id"]
-    assert record3["name"] == "client:signals"
+    record4 = fake_transport.records[3].asdict()
+    assert record3["parentId"] == record4["id"]
+    assert record2["parentId"] == record4["id"]
+    assert record1["parentId"] == record4["id"]
+    assert record4["name"] == "client:signals"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What do these changes do?

Currently trace config handlers support only `dict` as trace request context which is not compatible with `aiohttp`. `aiohttp` expects context to be of type `SimpleNamespace` (https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client.py#L333)

## Are there changes in behavior for the user?

No changes.

## Related issue number

No issue.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
