### PR TITLE
Fix unhandled AssertionError in aiohttp integration when unknown resource requested by the user

### DIFF
--- a/CHANGES/400.bugfix
+++ b/CHANGES/400.bugfix
@@ -1,0 +1,1 @@
+Fix unhandled AssertionError in aiohttp integration when unknown resource requested by the user.

--- a/aiozipkin/aiohttp_helpers.py
+++ b/aiozipkin/aiohttp_helpers.py
@@ -99,9 +99,9 @@ def _set_span_properties(span: SpanAbc, request: Request) -> None:
     span.tag(HTTP_METHOD, request.method.upper())
 
     resource = request.match_info.route.resource
-    assert resource is not None
-    route = resource.canonical
-    span.tag(HTTP_ROUTE, route)
+    if resource is not None:
+        route = resource.canonical
+        span.tag(HTTP_ROUTE, route)
 
     _set_remote_endpoint(span, request)
 

--- a/tests/test_aiohttp_integration.py
+++ b/tests/test_aiohttp_integration.py
@@ -131,3 +131,14 @@ async def test_client_signals_no_span(tracer: az.Tracer, fake_transport: Any) ->
     assert len(data) > 0
     await session.close()
     assert len(fake_transport.records) == 0
+
+
+@pytest.mark.asyncio
+async def test_no_resource(
+    client: aiohttp.ClientSession, fake_transport: Any
+) -> None:
+    resp = await client.get("/404")
+    assert resp.status == 404
+    assert len(fake_transport.records) == 1
+    record1 = fake_transport.records[0].asdict()
+    assert record1["tags"]["http.status_code"] == "404"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
<!-- Please give a short brief about these changes. -->
aiohttp integration causes an unhandled AssertionError when client requests a path without a resource bound to it. This change fixes it.

## Are there changes in behavior for the user?
<!-- Outline any notable behaviour for the end users. -->
There is a proper 404 now instead of 500 for the clients of an application with aiozipkin's aiohttp integration when they are requesting an URL unknown to the app.

## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->
I have not found an open related issues.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
  It's a bugfix, IMO no documentation change required
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
